### PR TITLE
Regain parallelism when serializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,34 +20,18 @@ extern crate amethyst_editor_sync;
 
 use amethyst_editor_sync::*;
 
-// Create a root `SyncEditorSystem` to coordinate sending all data to the editor.
-let editor_system = SyncEditorSystem::new();
+// Create a `SyncEditorBundle` which will register all necessary systems to serialize and send
+// data to the editor. 
+let editor_bundle = SyncEditorBundle::new()
+    // Register any engine-specific components you want to visualize.
+    .sync_component::<Transform>("Transform")
+    // Register any custom components that you use in your game.
+    .sync_component::<Foo>("Foo")
+    // Register any resources that you want to view in the editor.
+    .sync_resource::<AmbientColor>("AmbientColor");
 
 let game_data = GameDataBuilder::default()
-    // Register the systems for your game first.
-
-    // Insert a barrier to ensure that the editor syncing runs after all
-    // other systems have finished.
-    .with_barrier()
-
-    // Register any engine-specific components you want to visualize.
-    .with(
-        SyncComponentSystem::<Transform>::new("Transform", &editor_system),
-        "editor_transform",
-        &[],
-    )
-
-    // Register any custom components that you use in your game.
-    .with(
-        SyncComponentSystem::<Foo>::new("Foo", &editor_system),
-        "editor_foo",
-        &[],
-    )
-
-    // Register the `SyncEditorSystem` as thread local to ensure it runs last,
-    // after the other systems have had a chance to serialize the state data
-    // for all components/resources.
-    .with_thread_local(editor_system);
+    .with_bundle(editor_bundle)?; 
 
 // Make sure you enable serialization for your custom components and resources!
 #[derive(Serialize, Deserialize)]

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -80,7 +80,7 @@ fn main() -> amethyst::Result<()> {
 
     let assets_dir = format!("{}/examples/assets/", env!("CARGO_MANIFEST_DIR"));
 
-    let editor_system = SyncEditorSystem::new()
+    let editor_sync_bundle = SyncEditorBundle::new()
         .sync_component::<Transform>("Transform")
         .sync_component::<Ball>("Ball")
         .sync_component::<Paddle>("Paddle")
@@ -94,7 +94,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new().with_dep(&["ball_system", "paddle_system"]))?
         .with_bundle(AudioBundle::new(|music: &mut Music| music.music.next()))?
         .with_bundle(UiBundle::<String, String>::new())?
-        .with_thread_local(editor_system);
+        .with_bundle(editor_sync_bundle)?;
     let mut game = Application::build(assets_dir, Pong)?
         .with_frame_limit(
             FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 //! Provides functionality that allows an Amethyst game to communicate with an editor.
 //!
 //! [`SyncEditorSystem`] is the root system that will send your game's state data to an editor.
-//! In order to visualize your game's state in an editor, you'll also need to register each component
-//! and resource that you want to visualize.
+//! In order to visualize your game's state in an editor, you'll also need to create a
+//! [`SyncComponentSystem`] or [`SyncResourceSystem`] for each component and resource that you want
+//! to visualize. It is possible to automatically create these systems by creating a
+//! [`SyncEditorBundle`] and registering each component and resource on it instead.
 //!
 //! # Example
 //!
@@ -13,16 +15,16 @@
 //! use amethyst::*;
 //! use amethyst_editor_sync::*;
 //!
-//! // Create a root `SyncEditorSystem` to coordinate sending all data to the editor.
-//! let editor_system = SyncEditorSystem::new()
+//! // Create a `SyncEditorBundle` which will create all necessary systems to send the components
+//! // to the editor.
+//! let editor_sync_bundle = SyncEditorBundle::new()
 //!     // Register any engine-specific components you want to visualize.
 //!     .sync_component::<Transform>("Transform")
 //!     // Register any custom components that you use in your game.
 //!     .sync_component::<Foo>("Foo")
 //!
 //! let game_data = GameDataBuilder::default()
-//!     // Register the `SyncEditorSystem` as thread local to ensure it runs last.
-//!     .with_thread_local(editor_system);
+//!     .with_bundle(editor_sync_bundle)?;
 //!
 //! // Make sure you enable serialization for your custom components and resources!
 //! #[derive(Serialize, Deserialize)]
@@ -34,7 +36,7 @@
 //!
 //! # Usage
 //!
-//! First, create a [`SyncEditorSystem`] object. You must then register each of the component and
+//! First, create a [`SyncEditorBundle`] object. You must then register each of the component and
 //! resource types that you want to see in the editor:
 //!
 //! * For each component `T`, register the component with `sync_component::<T>(name)`, specifying
@@ -42,7 +44,7 @@
 //! * For each resource, register the component with `sync_resource::<T>(name)`, specifying the
 //!   name of the resource and its concrete type.
 //!
-//! Finally, register the [`SyncEditorSystem`] that you first created as a thread-local system.
+//! Finally, add the [`SyncEditorBundle`] that you created to the game data.
 
 extern crate amethyst;
 extern crate crossbeam_channel;
@@ -53,8 +55,8 @@ extern crate serde;
 extern crate serde_json;
 
 use std::collections::HashMap;
+use amethyst::core::bundle::{Result as BundleResult, SystemBundle};
 use amethyst::ecs::*;
-use amethyst::ecs::world::EntitiesRes;
 use amethyst::shred::Resource;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Serialize;
@@ -84,72 +86,115 @@ struct SerializedResource<'a, T: 'a> {
     data: &'a T,
 }
 
-/// Syncs all components and resources specified by the types.
-///
-/// T is a list of all synced component types.
-/// U is a list of all synced resource types.
-pub struct SyncEditorSystem<T, U> {
+enum SerializedData {
+    Resource(String),
+    Component(String),
+}
+
+/// Bundles all necessary systems for serializing all registered components and resources and
+/// sending them to the editor.
+pub struct SyncEditorBundle<T, U> where
+    T: ComponentSet,
+    U: ResourceSet,
+{
     component_names: Vec<&'static str>,
     resource_names: Vec<&'static str>,
-    socket: UdpSocket,
     _phantom: PhantomData<(T, U)>,
 }
 
-impl SyncEditorSystem<(), ()> {
-    pub fn new() -> SyncEditorSystem<(), ()> {
-        // Setup the socket for communicating with the editor and add it as a resource.
-        let socket = UdpSocket::bind("0.0.0.0:0").expect("Failed to bind socket");
-        socket.connect("127.0.0.1:8000").expect("Failed to connect to editor");
-
-        SyncEditorSystem {
+impl SyncEditorBundle<(), ()> {
+    /// Construct an empty bundle.
+    pub fn new() -> SyncEditorBundle<(), ()> {
+        SyncEditorBundle {
             component_names: Vec::new(),
             resource_names: Vec::new(),
-            socket,
             _phantom: PhantomData,
         }
     }
 }
 
-impl<T, U> SyncEditorSystem<T, U> {
-    pub fn sync_component<C>(mut self, name: &'static str) -> SyncEditorSystem<(C, T), U>
+impl<T, U> SyncEditorBundle<T, U> where
+    T: ComponentSet,
+    U: ResourceSet,
+{
+    /// Register a component for synchronizing with the editor. This will result in a
+    /// [`SyncComponentSystem`] being added.
+    pub fn sync_component<C>(mut self, name: &'static str) -> SyncEditorBundle<(C, T), U>
     where
-        C: Component + Serialize,
+        C: Component + Serialize+Send,
     {
         self.component_names.push(name);
-        SyncEditorSystem {
+        SyncEditorBundle {
             component_names: self.component_names,
             resource_names: self.resource_names,
-            socket: self.socket,
             _phantom: PhantomData,
         }
     }
 
-    pub fn sync_resource<R>(mut self, name: &'static str) -> SyncEditorSystem<T, (R, U)>
+    /// Register a resource for synchronizing with the editor. This will result in a
+    /// [`SyncResourceSystem`] being added.
+    pub fn sync_resource<R>(mut self, name: &'static str) -> SyncEditorBundle<T, (R, U)>
     where
         R: Resource + Serialize,
     {
         self.resource_names.push(name);
-        SyncEditorSystem {
+        SyncEditorBundle {
             component_names: self.component_names,
             resource_names: self.resource_names,
-            socket: self.socket,
             _phantom: PhantomData,
         }
     }
 }
-
-impl<'a, T, U> System<'a> for SyncEditorSystem<T, U>
-where
-    T: ComponentSet<'a>,
-    U: ResourceSet<'a>,
+impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
+    T: ComponentSet,
+    U: ResourceSet,
 {
-    type SystemData = (Entities<'a>, T::SystemData, U::SystemData);
+    fn build(mut self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {
+        // In order to match the order of the type list.
+        self.component_names.reverse();
+        self.resource_names.reverse();
 
-    fn run(&mut self, (entities, components, resources): Self::SystemData) {
-        let components_string =
-            T::serialize_json(&*entities, components, &self.component_names).join(",");
-        let resources_string =
-            U::serialize_json(resources, &self.resource_names).join(",");
+        let sync_system = SyncEditorSystem::new();
+        // All systems must have finished editing data before syncing can start.
+        dispatcher.add_barrier();
+        T::create_sync_systems(dispatcher, &sync_system, &self.component_names);
+        U::create_sync_systems(dispatcher, &sync_system, &self.resource_names);
+        // All systems must have finished serializing before it can be send to the editor.
+        dispatcher.add_barrier();
+        dispatcher.add(sync_system, "", &[]);
+        Ok(())
+    }
+}
+
+/// A system that is in charge of coordinating a number of serialization systems and sending
+/// their results to the editor.
+pub struct SyncEditorSystem {
+    receiver: Receiver<SerializedData>,
+    sender: Sender<SerializedData>,
+    socket: UdpSocket,
+}
+
+impl SyncEditorSystem {
+    fn new() -> Self {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let socket = UdpSocket::bind("0.0.0.0:0").expect("Failed to bind socket");
+        socket.connect("127.0.0.1:8000").expect("Failed to connect to editor");
+        Self { receiver, sender, socket }
+    }
+}
+
+impl<'a> System<'a> for SyncEditorSystem {
+    type SystemData = Entities<'a>;
+
+    fn run(&mut self, entities: Self::SystemData) {
+        let mut components = Vec::new();
+        let mut resources = Vec::new();
+        while let Some(serialized) = self.receiver.try_recv() {
+            match serialized {
+                SerializedData::Component(c) => components.push(c),
+                SerializedData::Resource(r) => resources.push(r),
+            }
+        }
 
         let mut entity_data = Vec::<SerializableEntity>::new();
         for (entity,) in (&*entities,).join() {
@@ -168,8 +213,9 @@ where
                 }}
             }}"#,
             entity_string,
-            components_string,
-            resources_string,
+            // Insert a comma between components so that it's valid JSON.
+            components.join(","),
+            resources.join(","),
         );
 
         trace!("{}", message_string);
@@ -181,92 +227,112 @@ where
         // Send the JSON message.
         self.socket.send(message_string.as_bytes()).expect("Failed to send message");
     }
+}
 
-    fn setup(&mut self, res: &mut Resources) {
-        Self::SystemData::setup(res);
-        // In order to match the order of the type list.
-        self.component_names.reverse();
-        self.resource_names.reverse();
+/// A system that serializes all components of a specific type and sends them to the
+/// [`SyncEditorSystem`], which will sync them with the editor.
+pub struct SyncComponentSystem<T> {
+    name: &'static str,
+    sender: Sender<SerializedData>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> SyncComponentSystem<T> {
+    pub fn new(name: &'static str, sync_system: &SyncEditorSystem) -> Self {
+        Self {
+            name,
+            sender: sync_system.sender.clone(),
+            _phantom: PhantomData,
+        }
     }
 }
 
-pub trait ComponentSet<'a> {
-    type SystemData: SystemData<'a>;
+impl<'a, T> System<'a> for SyncComponentSystem<T> where T: Component+Serialize {
+    type SystemData = (Entities<'a>, ReadStorage<'a, T>);
 
-    /// Serialize each component in a json map. Does not need to return the components in order.
-    fn serialize_json(
-        entities: &EntitiesRes,
-        data: Self::SystemData,
-        names: &[&'static str],
-    ) -> Vec<String>;
-}
-
-impl<'a> ComponentSet<'a> for () {
-    type SystemData = ();
-
-    fn serialize_json(_: &EntitiesRes, _: Self::SystemData, _: &[&'static str]) -> Vec<String> {
-        Vec::new()
-    }
-}
-
-impl<'a, A, B> ComponentSet<'a> for (A, B)
-where
-    A: Component + Serialize,
-    B: ComponentSet<'a>,
-{
-    type SystemData = (ReadStorage<'a, A>, B::SystemData);
-
-    fn serialize_json(
-        entities: &EntitiesRes,
-        (component, component_rest): Self::SystemData,
-        names: &[&'static str],
-    ) -> Vec<String> {
-        let mut res = B::serialize_json(entities, component_rest, &names[1..]);
-        let component_data = (entities, &component)
+    fn run(&mut self, (entities, components): Self::SystemData) {
+        let data = (&*entities, &components)
             .join()
             .map(|(e, c)| (e.id(), c))
             .collect();
-        let json = serde_json::to_string(&SerializedComponent {
-            name: names[0],
-            data: component_data,
-        }).expect("Failed to serialize message");
-        res.push(json);
-        res
+        let serialize_data = SerializedComponent { name: self.name, data };
+        if let Ok(serialized) = serde_json::to_string(&serialize_data) {
+            self.sender.send(SerializedData::Component(serialized));
+        } else {
+            error!("Failed to serialize component of type {}", self.name);
+        }
     }
 }
 
-pub trait ResourceSet<'a> {
-    type SystemData: SystemData<'a>;
-
-    /// Serialize each resource. Does not need to return the resources in order.
-    fn serialize_json(data: Self::SystemData, names: &[&'static str]) -> Vec<String>;
+/// A system that serializes a resource of a specific type and sends it to the
+/// [`SyncEditorSystem`], which will sync it with the editor.
+pub struct SyncResourceSystem<T> {
+    name: &'static str,
+    sender: Sender<SerializedData>,
+    _phantom: PhantomData<T>,
 }
 
-impl<'a> ResourceSet<'a> for () {
-    type SystemData = ();
-
-    fn serialize_json(_: Self::SystemData, _: &[&'static str]) -> Vec<String> {
-        Vec::new()
+impl<T> SyncResourceSystem<T> {
+    pub fn new(name: &'static str, sync_system: &SyncEditorSystem) -> Self {
+        Self {
+            name,
+            sender: sync_system.sender.clone(),
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, A, B> ResourceSet<'a> for (A, B)
+impl<'a, T> System<'a> for SyncResourceSystem<T> where T: Resource+Serialize {
+    type SystemData = ReadExpect<'a, T>;
+
+    fn run(&mut self, resource: Self::SystemData) {
+        let serialize_data = SerializedResource {
+            name: self.name,
+            data: &*resource,
+        };
+        if let Ok(serialized) = serde_json::to_string(&serialize_data) {
+            self.sender.send(SerializedData::Resource(serialized));
+        } else {
+            error!("Failed to serialize resource of type {}", self.name);
+        }
+    }
+}
+
+
+pub trait ComponentSet {
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]);
+}
+
+impl ComponentSet for () {
+    fn create_sync_systems(_: &mut DispatcherBuilder, _: &SyncEditorSystem, _: &[&'static str]) { }
+}
+
+impl<A, B> ComponentSet for (A, B)
+where
+    A: Component + Serialize + Send,
+    B: ComponentSet,
+{
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]) {
+        B::create_sync_systems(dispatcher, sync_system, &names[1..]);
+        dispatcher.add(SyncComponentSystem::<A>::new(names[0], sync_system), "", &[]);
+    }
+}
+
+pub trait ResourceSet {
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]);
+}
+
+impl ResourceSet for () {
+    fn create_sync_systems(_: &mut DispatcherBuilder, _: &SyncEditorSystem, _: &[&'static str]) { }
+}
+
+impl<A, B> ResourceSet for (A, B)
 where
     A: Resource + Serialize,
-    B: ResourceSet<'a>,
+    B: ResourceSet,
 {
-    type SystemData = (ReadExpect<'a, A>, B::SystemData);
-
-    fn serialize_json(
-        (resource, resource_rest): Self::SystemData,
-        names: &[&'static str],
-    ) -> Vec<String> {
-        let mut res = B::serialize_json(resource_rest, &names[1..]);
-        let json = serde_json::to_string(&SerializedResource {
-            name: names[0],
-            data: &*resource,
-        }).expect("Failed to serialize resource");
-        res.push(json);
-        res
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]) {
+        B::create_sync_systems(dispatcher, sync_system, &names[1..]);
+        dispatcher.add(SyncResourceSystem::<A>::new(names[0], sync_system), "", &[]);
     }
 }


### PR DESCRIPTION
Uses the same setup for registering resources and components, but create a bundle instead of a system. This allows creating multiple systems for serializing components and resources which can be run in parallel.

resolves #4 