### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+cache: cargo
+
+# Install ALSA development libraries before compiling on Linux.
+addons:
+  apt:
+    packages:
+        - libasound2-dev

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //! #[macro_use]
 //! extern crate serde;
 //!
-//! use amethyst::*;
-//! use amethyst::core::*;
+//! use amethyst::core::Transform;
 //! use amethyst::ecs::*;
+//! use amethyst::prelude::*;
 //! use amethyst_editor_sync::*;
 //!
 //! # fn main() -> Result<(), amethyst::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! ```
 //! extern crate amethyst;
 //! extern crate amethyst_editor_sync;
+//! #[macro_use]
+//! extern crate serde;
 //!
 //! use amethyst::*;
 //! use amethyst::core::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,10 @@
 //!
 //! use amethyst::*;
 //! use amethyst::core::*;
+//! use amethyst::ecs::*;
 //! use amethyst_editor_sync::*;
 //!
+//! # fn main() -> Result<(), amethyst::Error> {
 //! // Create a `SyncEditorBundle` which will create all necessary systems to send the components
 //! // to the editor.
 //! let editor_sync_bundle = SyncEditorBundle::new()
@@ -28,12 +30,18 @@
 //!
 //! let game_data = GameDataBuilder::default()
 //!     .with_bundle(editor_sync_bundle)?;
+//! # Ok(())
+//! # }
 //!
 //! // Make sure you enable serialization for your custom components and resources!
 //! #[derive(Serialize, Deserialize)]
 //! struct Foo {
 //!     bar: usize,
 //!     baz: String,
+//! }
+//!
+//! impl Component for Foo {
+//!     type Storage = DenseVecStorage<Self>;
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! extern crate amethyst_editor_sync;
 //!
 //! use amethyst::*;
+//! use amethyst::core::*;
 //! use amethyst_editor_sync::*;
 //!
 //! // Create a `SyncEditorBundle` which will create all necessary systems to send the components

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!     // Register any engine-specific components you want to visualize.
 //!     .sync_component::<Transform>("Transform")
 //!     // Register any custom components that you use in your game.
-//!     .sync_component::<Foo>("Foo")
+//!     .sync_component::<Foo>("Foo");
 //!
 //! let game_data = GameDataBuilder::default()
 //!     .with_bundle(editor_sync_bundle)?;


### PR DESCRIPTION
Sets up Travis CI with the default configuration. This should be sufficient for our purposes, since the crate is very simple and shouldn't be performing any platform-specific work.

Resolves #5