### PR TITLE
Add logger which sends output to the editor

### DIFF
--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -47,8 +47,6 @@ const AUDIO_BOUNCE: &'static str = "audio/bounce.ogg";
 const AUDIO_SCORE: &'static str = "audio/score.ogg";
 
 fn main() -> amethyst::Result<()> {
-    env_logger::init();
-
     use pong::Pong;
 
     let display_config_path = format!(
@@ -85,6 +83,7 @@ fn main() -> amethyst::Result<()> {
         .sync_component::<Ball>("Ball")
         .sync_component::<Paddle>("Paddle")
         .sync_resource::<ScoreBoard>("ScoreBoard");
+    EditorLogger::new(editor_sync_bundle.get_connection()).start();
     let game_data = GameDataBuilder::default()
         .with_bundle(
             InputBundle::<String, String>::new().with_bindings_from_file(&key_bindings_path)?,

--- a/src/editor_log.rs
+++ b/src/editor_log.rs
@@ -1,0 +1,81 @@
+use log;
+use log::{Level, Log, Metadata, Record};
+
+use EditorConnection;
+
+/// A `Log` implementation that sends all incoming logs to the editor, which may allow more
+/// interactive filtering.
+pub struct EditorLogger {
+    editor_connection: EditorConnection,
+}
+
+impl EditorLogger {
+    /// Construct a logger that sends logs to the given editor.
+    pub fn new(editor_connection: EditorConnection) -> Self {
+        Self { editor_connection }
+    }
+
+    /// Start this logger if no current logger is set.
+    pub fn start(self) {
+        log::set_max_level(log::LevelFilter::max());
+        log::set_boxed_logger(Box::new(self))
+            .unwrap_or_else(|_| warn!("Logger already set. The editor will not receive any logs."));
+    }
+}
+
+impl Log for EditorLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        self.editor_connection
+            .send_message("log", SerializableLogRecord::from(record));
+    }
+
+    fn flush(&self) {}
+}
+
+#[derive(Debug, Serialize)]
+enum SerializableLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<Level> for SerializableLevel {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Error => SerializableLevel::Error,
+            Level::Warn => SerializableLevel::Warn,
+            Level::Info => SerializableLevel::Info,
+            Level::Debug => SerializableLevel::Debug,
+            Level::Trace => SerializableLevel::Trace,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SerializableLogRecord {
+    level: SerializableLevel,
+    target: String,
+    module: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+    message: String,
+}
+
+impl<'a> From<&'a Record<'a>> for SerializableLogRecord {
+    fn from(record: &Record) -> Self {
+        Self {
+            level: record.level().into(),
+            target: record.target().to_owned(),
+            module: record.module_path().map(|s| s.to_owned()),
+            file: record.file().map(|s| s.to_owned()),
+            line: record.line(),
+            message: format!("{}", record.args()),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,26 @@ enum SerializedData {
     Component(String),
 }
 
+/// A connection to an editor which allows sending messages via a [`SyncEditorSystem`].
+///
+/// Anything that needs to be able to send messages to the editor needs such a connection.
+#[derive(Clone)]
+pub struct EditorConnection {
+    sender: Sender<SerializedData>,
+}
+
+impl EditorConnection {
+    /// Construct a connection to the editor via sending messages to the [`SyncEditorSystem`].
+    fn new(sender: Sender<SerializedData>) -> Self {
+        Self { sender }
+    }
+
+    /// Send serialized data to the editor.
+    fn send_data(&self, data: SerializedData) {
+        self.sender.send(data);
+    }
+}
+
 /// Bundles all necessary systems for serializing all registered components and resources and
 /// sending them to the editor.
 pub struct SyncEditorBundle<T, U> where
@@ -110,15 +130,20 @@ pub struct SyncEditorBundle<T, U> where
 {
     component_names: Vec<&'static str>,
     resource_names: Vec<&'static str>,
+    sender: Sender<SerializedData>,
+    receiver: Receiver<SerializedData>,
     _phantom: PhantomData<(T, U)>,
 }
 
 impl SyncEditorBundle<(), ()> {
     /// Construct an empty bundle.
     pub fn new() -> SyncEditorBundle<(), ()> {
+        let (sender, receiver) = crossbeam_channel::unbounded();
         SyncEditorBundle {
             component_names: Vec::new(),
             resource_names: Vec::new(),
+            sender,
+            receiver,
             _phantom: PhantomData,
         }
     }
@@ -138,6 +163,8 @@ impl<T, U> SyncEditorBundle<T, U> where
         SyncEditorBundle {
             component_names: self.component_names,
             resource_names: self.resource_names,
+            sender: self.sender,
+            receiver: self.receiver,
             _phantom: PhantomData,
         }
     }
@@ -152,10 +179,18 @@ impl<T, U> SyncEditorBundle<T, U> where
         SyncEditorBundle {
             component_names: self.component_names,
             resource_names: self.resource_names,
+            sender: self.sender,
+            receiver: self.receiver,
             _phantom: PhantomData,
         }
     }
+
+    /// Retrieve a connection to send messages to the editor via the [`SyncEditorSystem`].
+    pub fn get_connection(&self) -> EditorConnection {
+        EditorConnection::new(self.sender.clone())
+    }
 }
+
 impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
@@ -165,11 +200,12 @@ impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
         self.component_names.reverse();
         self.resource_names.reverse();
 
-        let sync_system = SyncEditorSystem::new();
+        let sync_system = SyncEditorSystem::from_channel(self.sender, self.receiver);
+        let connection = sync_system.get_connection();
         // All systems must have finished editing data before syncing can start.
         dispatcher.add_barrier();
-        T::create_sync_systems(dispatcher, &sync_system, &self.component_names);
-        U::create_sync_systems(dispatcher, &sync_system, &self.resource_names);
+        T::create_sync_systems(dispatcher, &connection, &self.component_names);
+        U::create_sync_systems(dispatcher, &connection, &self.resource_names);
         // All systems must have finished serializing before it can be send to the editor.
         dispatcher.add_barrier();
         dispatcher.add(sync_system, "", &[]);
@@ -186,11 +222,20 @@ pub struct SyncEditorSystem {
 }
 
 impl SyncEditorSystem {
-    fn new() -> Self {
+    pub fn new() -> Self {
         let (sender, receiver) = crossbeam_channel::unbounded();
+        Self::from_channel(sender, receiver)
+    }
+
+    fn from_channel(sender: Sender<SerializedData>, receiver: Receiver<SerializedData>) -> Self {
         let socket = UdpSocket::bind("0.0.0.0:0").expect("Failed to bind socket");
         socket.connect("127.0.0.1:8000").expect("Failed to connect to editor");
         Self { receiver, sender, socket }
+    }
+
+    /// Retrieve a connection to the editor via this system.
+    pub fn get_connection(&self) -> EditorConnection {
+        EditorConnection::new(self.sender.clone())
     }
 }
 
@@ -244,15 +289,15 @@ impl<'a> System<'a> for SyncEditorSystem {
 /// [`SyncEditorSystem`], which will sync them with the editor.
 pub struct SyncComponentSystem<T> {
     name: &'static str,
-    sender: Sender<SerializedData>,
+    connection: EditorConnection,
     _phantom: PhantomData<T>,
 }
 
 impl<T> SyncComponentSystem<T> {
-    pub fn new(name: &'static str, sync_system: &SyncEditorSystem) -> Self {
+    pub fn new(name: &'static str, connection: EditorConnection) -> Self {
         Self {
             name,
-            sender: sync_system.sender.clone(),
+            connection,
             _phantom: PhantomData,
         }
     }
@@ -268,7 +313,7 @@ impl<'a, T> System<'a> for SyncComponentSystem<T> where T: Component+Serialize {
             .collect();
         let serialize_data = SerializedComponent { name: self.name, data };
         if let Ok(serialized) = serde_json::to_string(&serialize_data) {
-            self.sender.send(SerializedData::Component(serialized));
+            self.connection.send_data(SerializedData::Component(serialized));
         } else {
             error!("Failed to serialize component of type {}", self.name);
         }
@@ -279,15 +324,15 @@ impl<'a, T> System<'a> for SyncComponentSystem<T> where T: Component+Serialize {
 /// [`SyncEditorSystem`], which will sync it with the editor.
 pub struct SyncResourceSystem<T> {
     name: &'static str,
-    sender: Sender<SerializedData>,
+    connection: EditorConnection,
     _phantom: PhantomData<T>,
 }
 
 impl<T> SyncResourceSystem<T> {
-    pub fn new(name: &'static str, sync_system: &SyncEditorSystem) -> Self {
+    pub fn new(name: &'static str, connection: EditorConnection) -> Self {
         Self {
             name,
-            sender: sync_system.sender.clone(),
+            connection,
             _phantom: PhantomData,
         }
     }
@@ -302,7 +347,7 @@ impl<'a, T> System<'a> for SyncResourceSystem<T> where T: Resource+Serialize {
             data: &*resource,
         };
         if let Ok(serialized) = serde_json::to_string(&serialize_data) {
-            self.sender.send(SerializedData::Resource(serialized));
+            self.connection.send_data(SerializedData::Resource(serialized));
         } else {
             error!("Failed to serialize resource of type {}", self.name);
         }
@@ -311,11 +356,11 @@ impl<'a, T> System<'a> for SyncResourceSystem<T> where T: Resource+Serialize {
 
 
 pub trait ComponentSet {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]);
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]);
 }
 
 impl ComponentSet for () {
-    fn create_sync_systems(_: &mut DispatcherBuilder, _: &SyncEditorSystem, _: &[&'static str]) { }
+    fn create_sync_systems(_: &mut DispatcherBuilder, _: &EditorConnection, _: &[&'static str]) { }
 }
 
 impl<A, B> ComponentSet for (A, B)
@@ -323,18 +368,18 @@ where
     A: Component + Serialize + Send,
     B: ComponentSet,
 {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]) {
-        B::create_sync_systems(dispatcher, sync_system, &names[1..]);
-        dispatcher.add(SyncComponentSystem::<A>::new(names[0], sync_system), "", &[]);
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]) {
+        B::create_sync_systems(dispatcher, connection, &names[1..]);
+        dispatcher.add(SyncComponentSystem::<A>::new(names[0], connection.clone()), "", &[]);
     }
 }
 
 pub trait ResourceSet {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]);
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]);
 }
 
 impl ResourceSet for () {
-    fn create_sync_systems(_: &mut DispatcherBuilder, _: &SyncEditorSystem, _: &[&'static str]) { }
+    fn create_sync_systems(_: &mut DispatcherBuilder, _: &EditorConnection, _: &[&'static str]) { }
 }
 
 impl<A, B> ResourceSet for (A, B)
@@ -342,8 +387,8 @@ where
     A: Resource + Serialize,
     B: ResourceSet,
 {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, sync_system: &SyncEditorSystem, names: &[&'static str]) {
-        B::create_sync_systems(dispatcher, sync_system, &names[1..]);
-        dispatcher.add(SyncResourceSystem::<A>::new(names[0], sync_system), "", &[]);
+    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]) {
+        B::create_sync_systems(dispatcher, connection, &names[1..]);
+        dispatcher.add(SyncResourceSystem::<A>::new(names[0], connection.clone()), "", &[]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,10 @@ use serde::Serialize;
 use serde::export::PhantomData;
 use std::net::UdpSocket;
 
+pub use editor_log::EditorLogger;
 pub use ::serializable_entity::SerializableEntity;
 
+mod editor_log;
 mod serializable_entity;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -293,8 +295,6 @@ impl<'a> System<'a> for SyncEditorSystem {
             resources.join(","),
             messages.join(","),
         );
-
-        trace!("{}", message_string);
 
         // NOTE: We need to append a page feed character after each message since that's what node-ipc
         // expects to delimit messages.


### PR DESCRIPTION
This is done by exposing an EditorConnection which can be used to send arbitrary messages to the editor.

Currently the user will have to replace the builtin amethyst logger to use this logger. I'm thinking that this should be solved in the main repo by making the amethyst logger support chaining to custom loggers.

Resolves #6 
