### PR TITLE
Handle missing resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "amethyst-editor-sync"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "amethyst 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -1,0 +1,78 @@
+extern crate amethyst;
+extern crate amethyst_editor_sync;
+#[macro_use]
+extern crate serde;
+
+use amethyst::prelude::*;
+use amethyst_editor_sync::*;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct SimpleResource {
+    value: usize,
+}
+
+#[test]
+fn serialize_resource() -> amethyst::Result<()> {
+    #[derive(Debug, Clone, Copy, Default)]
+    struct TestState {
+        frames: usize,
+    };
+
+    impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
+        fn on_start(&mut self, data: StateData<GameData>) {
+            data.world.add_resource(SimpleResource {
+                value: 123,
+            });
+        }
+
+        fn update(&mut self, _: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+            self.frames += 1;
+            if self.frames > 10 {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        }
+    }
+
+    let editor_sync_bundle = SyncEditorBundle::new()
+        .sync_resource::<SimpleResource>("Test State");
+    let game_data = GameDataBuilder::default()
+        .with_bundle(editor_sync_bundle)?;
+    let mut game = Application::build(".", TestState::default())?
+        .build(game_data)?;
+
+    game.run();
+
+    Ok(())
+}
+
+#[test]
+fn missing_resource() -> amethyst::Result<()> {
+    #[derive(Debug, Clone, Copy, Default)]
+    struct TestState {
+        frames: usize,
+    };
+
+    impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
+        fn update(&mut self, _: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+            self.frames += 1;
+            if self.frames > 10 {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        }
+    }
+
+    let editor_sync_bundle = SyncEditorBundle::new()
+        .sync_resource::<SimpleResource>("Test State");
+    let game_data = GameDataBuilder::default()
+        .with_bundle(editor_sync_bundle)?;
+    let mut game = Application::build(".", TestState::default())?
+        .build(game_data)?;
+
+    game.run();
+
+    Ok(())
+}

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -25,7 +25,9 @@ fn serialize_resource() -> amethyst::Result<()> {
             });
         }
 
-        fn update(&mut self, _: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+        fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+            data.data.update(&data.world);
+
             self.frames += 1;
             if self.frames > 10 {
                 Trans::Quit
@@ -55,7 +57,9 @@ fn missing_resource() -> amethyst::Result<()> {
     };
 
     impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
-        fn update(&mut self, _: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+        fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+            data.data.update(&data.world);
+
             self.frames += 1;
             if self.frames > 10 {
                 Trans::Quit


### PR DESCRIPTION
Fixes #13 

Per @jojolepro's suggestion, use `Option<Read<T>>` instead of `ReadExpect<T>` so that we can gracefully handle the case where a resource is missing. For now I'm setting this up to warn about missing resources, but we can change that if it seems like the wrong approach.