### PR TITLE
Split messages into multiple UDP packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Panic if resource is missing. ([#14])
 * Panic on Linux if no editor is running. ([#15])
+* Panic if sync messages are too large. ([#17])
 
 [#14]: https://github.com/randomPoison/amethyst-editor-sync/pull/14
 [#15]: https://github.com/randomPoison/amethyst-editor-sync/issues/15
+[#17]: https://github.com/randomPoison/amethyst-editor-sync/pull/17
 
 ## [0.1.0] - 2018-10-04
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub use ::serializable_entity::SerializableEntity;
 mod editor_log;
 mod serializable_entity;
 
-const MAX_PACKET_SIZE: usize = 1024;
+const MAX_PACKET_SIZE: usize = 32 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Message<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ extern crate log;
 extern crate serde;
 extern crate serde_json;
 
+use std::cmp::min;
+use std::fmt::Write;
 use std::collections::HashMap;
 use amethyst::core::bundle::{Result as BundleResult, SystemBundle};
 use amethyst::ecs::*;
@@ -79,6 +81,8 @@ pub use ::serializable_entity::SerializableEntity;
 
 mod editor_log;
 mod serializable_entity;
+
+const MAX_PACKET_SIZE: usize = 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Message<T> {
@@ -167,6 +171,10 @@ impl SyncEditorBundle<(), ()> {
     }
 }
 
+impl Default for SyncEditorBundle<(), ()> {
+    fn default() -> Self { SyncEditorBundle::new() }
+}
+
 impl<T, U> SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
@@ -220,13 +228,16 @@ impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
 
         let sync_system = SyncEditorSystem::from_channel(self.sender, self.receiver);
         let connection = sync_system.get_connection();
+
         // All systems must have finished editing data before syncing can start.
         dispatcher.add_barrier();
         T::create_sync_systems(dispatcher, &connection, &self.component_names);
         U::create_sync_systems(dispatcher, &connection, &self.resource_names);
+
         // All systems must have finished serializing before it can be send to the editor.
         dispatcher.add_barrier();
         dispatcher.add(sync_system, "", &[]);
+
         Ok(())
     }
 }
@@ -237,6 +248,9 @@ pub struct SyncEditorSystem {
     receiver: Receiver<SerializedData>,
     sender: Sender<SerializedData>,
     socket: UdpSocket,
+
+    scratch_string: String,
+    buffer: Vec<u8>,
 }
 
 impl SyncEditorSystem {
@@ -247,13 +261,19 @@ impl SyncEditorSystem {
 
     fn from_channel(sender: Sender<SerializedData>, receiver: Receiver<SerializedData>) -> Self {
         let socket = UdpSocket::bind("0.0.0.0:0").expect("Failed to bind socket");
-        Self { receiver, sender, socket }
+        let buffer = Vec::with_capacity(MAX_PACKET_SIZE);
+        let scratch_string = String::with_capacity(MAX_PACKET_SIZE);
+        Self { receiver, sender, socket, scratch_string, buffer }
     }
 
     /// Retrieve a connection to the editor via this system.
     pub fn get_connection(&self) -> EditorConnection {
         EditorConnection::new(self.sender.clone())
     }
+}
+
+impl Default for SyncEditorSystem {
+    fn default() -> Self { SyncEditorSystem::new() }
 }
 
 impl<'a> System<'a> for SyncEditorSystem {
@@ -275,10 +295,12 @@ impl<'a> System<'a> for SyncEditorSystem {
         for (entity,) in (&*entities,).join() {
             entity_data.push(entity.into());
         }
-        let entity_string = serde_json::to_string(&entity_data).expect("Failed to serialize entities");
+        let entity_string = serde_json::to_string(&entity_data)
+            .expect("Failed to serialize entities");
 
         // Create the message and serialize it to JSON.
-        let mut message_string = format!(
+        write!(
+            self.scratch_string,
             r#"{{
                 "type": "message",
                 "data": {{
@@ -289,19 +311,30 @@ impl<'a> System<'a> for SyncEditorSystem {
                 }}
             }}"#,
             entity_string,
+
             // Insert a comma between components so that it's valid JSON.
             components.join(","),
             resources.join(","),
             messages.join(","),
         );
 
-        // NOTE: We need to append a page feed character after each message since that's what node-ipc
-        // expects to delimit messages.
-        message_string.push_str("\u{C}");
+        // NOTE: We need to append a page feed character after each message since that's
+        // what node-ipc expects to delimit messages.
+        self.scratch_string.push_str("\u{C}");
 
-        // Send the JSON message.
-        self.socket.send_to(message_string.as_bytes(), "127.0.0.1:8000")
-            .expect("Failed to send message");
+        // Send the message, breaking it up into multiple packets if the message is too large.
+        let mut bytes_sent = 0;
+        while bytes_sent < self.scratch_string.len() {
+            let bytes_to_send = min(self.scratch_string.len() - bytes_sent, MAX_PACKET_SIZE);
+
+            // Send the JSON message.
+            self.socket.send_to(&self.buffer[..], "127.0.0.1:8000")
+                .expect("Failed to send message");
+
+            bytes_sent += bytes_to_send;
+        }
+
+        self.scratch_string.clear();
     }
 }
 

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -1,43 +1,70 @@
 extern crate amethyst;
 extern crate amethyst_editor_sync;
-#[macro_use]
-extern crate serde;
 
 use amethyst::prelude::*;
 use amethyst_editor_sync::*;
 
-#[test]
-fn many_entities() -> amethyst::Result<()> {
-    #[derive(Debug, Clone, Copy, Default)]
-    struct TestState {
-        frames: usize,
-    }
+#[derive(Debug, Clone, Copy, Default)]
+struct TestState {
+    num_entities: usize,
+    frames: usize,
+}
 
-    impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
-        fn on_start(&mut self, data: StateData<GameData>) {
-            for _ in 0..2_500 {
-                data.world.create_entity().build();
-            }
+impl TestState {
+    fn new(num_entities: usize) -> Self {
+        TestState {
+            num_entities,
+            frames: 0,
         }
+    }
+}
 
-        fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
-            data.data.update(&data.world);
-
-            self.frames += 1;
-            if self.frames > 10 {
-                Trans::Quit
-            } else {
-                Trans::None
-            }
+impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
+    fn on_start(&mut self, data: StateData<GameData>) {
+        for _ in 0..self.num_entities {
+            data.world.create_entity().build();
         }
     }
 
+    fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+        data.data.update(&data.world);
+
+        self.frames += 1;
+        if self.frames > 10 {
+            Trans::Quit
+        } else {
+            Trans::None
+        }
+    }
+}
+
+fn run_world(num_entities: usize) -> amethyst::Result<()> {
     let editor_sync_bundle = SyncEditorBundle::new();
     let game_data = GameDataBuilder::default()
         .with_bundle(editor_sync_bundle)?;
-    let mut game = Application::build(".", TestState::default())?
+    let mut game = Application::build(".", TestState::new(num_entities))?
         .build(game_data)?;
     game.run();
 
     Ok(())
+}
+
+#[test]
+fn small_world() -> amethyst::Result<()> {
+    run_world(500)
+}
+
+#[test]
+fn med_world() -> amethyst::Result<()> {
+    run_world(2_500)
+}
+
+#[test]
+fn large_world() -> amethyst::Result<()> {
+    run_world(10_000)
+}
+
+#[test]
+fn huge_world() -> amethyst::Result<()> {
+    run_world(100_000)
 }

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -1,0 +1,43 @@
+extern crate amethyst;
+extern crate amethyst_editor_sync;
+#[macro_use]
+extern crate serde;
+
+use amethyst::prelude::*;
+use amethyst_editor_sync::*;
+
+#[test]
+fn many_entities() -> amethyst::Result<()> {
+    #[derive(Debug, Clone, Copy, Default)]
+    struct TestState {
+        frames: usize,
+    }
+
+    impl<'a, 'b> State<GameData<'a, 'b>> for TestState {
+        fn on_start(&mut self, data: StateData<GameData>) {
+            for _ in 0..2_500 {
+                data.world.create_entity().build();
+            }
+        }
+
+        fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
+            data.data.update(&data.world);
+
+            self.frames += 1;
+            if self.frames > 10 {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        }
+    }
+
+    let editor_sync_bundle = SyncEditorBundle::new();
+    let game_data = GameDataBuilder::default()
+        .with_bundle(editor_sync_bundle)?;
+    let mut game = Application::build(".", TestState::default())?
+        .build(game_data)?;
+    game.run();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #12 

Adds a maximum size for packets and splits large messages across multiple UDP packets if necessary. Also fixes some clippy warnings, and adds some logic for reusing `String` allocations to help performance a bit.