### PR TITLE
Easier registering of many types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `sync_components` and `sync_resources` methods in `SyncEditorBundle` to synchronize all types in a `TypeSet`. `TypeSets` can be created through the `type_set!` macro to reduce the verbosity of synchronizing many types. ([#19])
+* `sync_default_types` method in `SyncEditorBundle` to easily synchronize some commonly used engine types. ([#20])
+
+[#19]: https://github.com/randomPoison/amethyst-editor-sync/issues/19
+[#20]: https://github.com/randomPoison/amethyst-editor-sync/issues/20
+
+### Changed
+
+* `SyncEditorBundle` type format. If the type is explicitly given, it will need to be updated. ([#21])
+
+[#21]: https://github.com/randomPoison/amethyst-editor-sync/pull/21
+
 ### Fixed
 
 * Panic if resource is missing. ([#14])

--- a/README.md
+++ b/README.md
@@ -17,19 +17,24 @@ facilitate development of other editor front-ends.
 Here's an example of how to setup an Amethyst game to communicate with the editor:
 
 ```rust
+#[macro_use]
 extern crate amethyst_editor_sync;
 
 use amethyst_editor_sync::*;
 
+// Specify every component that you want to view in the editor.
+let components = type_set![Foo, Bar];
+// Do the same for your resources.
+let resources = type_set![Baz];
+
 // Create a `SyncEditorBundle` which will register all necessary systems to serialize and send
 // data to the editor. 
 let editor_bundle = SyncEditorBundle::new()
-    // Register any engine-specific components you want to visualize.
-    .sync_component::<Transform>("Transform")
-    // Register any custom components that you use in your game.
-    .sync_component::<Foo>("Foo")
-    // Register any resources that you want to view in the editor.
-    .sync_resource::<AmbientColor>("AmbientColor");
+    // Register the default types from the engine.
+    .sync_default_types()
+    // Register the components and resources specified above.
+    .sync_components(&components)
+    .sync_resources(&resources);
 
 let game_data = GameDataBuilder::default()
     .with_bundle(editor_bundle)?; 

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use amethyst::audio::AudioBundle;
 use amethyst::core::frame_limiter::FrameRateLimitStrategy;
-use amethyst::core::transform::{Transform, TransformBundle};
+use amethyst::core::transform::TransformBundle;
 use amethyst::ecs::prelude::{Component, DenseVecStorage};
 use amethyst::input::InputBundle;
 use amethyst::prelude::*;
@@ -67,10 +67,10 @@ fn main() -> amethyst::Result<()> {
     };
 
     let assets_dir = format!("{}/examples/assets/", env!("CARGO_MANIFEST_DIR"));
+    let components = type_set![Ball, Paddle];
     let editor_sync_bundle = SyncEditorBundle::new()
-        .sync_component::<Transform>("Transform")
-        .sync_component::<Ball>("Ball")
-        .sync_component::<Paddle>("Paddle")
+        .sync_default_types()
+        .sync_components(&components)
         .sync_resource::<ScoreBoard>("ScoreBoard");
     EditorLogger::new(editor_sync_bundle.get_connection()).start();
     let game_data = GameDataBuilder::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ impl<T, U> SyncEditorBundle<T, U> where
         let components = type_set![Light, Camera, Transform, GlobalTransform];
         let resources = type_set![AmbientColor];
         SyncEditorBundle {
+            send_interval: self.send_interval,
             components: self.components.with_set(&components),
             resources: self.resources.with_set(&resources),
             sender: self.sender,
@@ -292,7 +293,7 @@ impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
 {
-    fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {a
+    fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {
         let sync_system = SyncEditorSystem::from_channel(
             self.sender,
             self.receiver,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,9 @@ use std::net::UdpSocket;
 
 pub use editor_log::EditorLogger;
 pub use ::serializable_entity::SerializableEntity;
+pub use type_set::{ComponentSet, ResourceSet, TypeSet};
 
+mod type_set;
 mod editor_log;
 mod serializable_entity;
 
@@ -149,12 +151,11 @@ impl EditorConnection {
 pub struct SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
-{
-    component_names: Vec<&'static str>,
-    resource_names: Vec<&'static str>,
+ {
+    components: TypeSet<T>,
+    resources: TypeSet<U>,
     sender: Sender<SerializedData>,
     receiver: Receiver<SerializedData>,
-    _phantom: PhantomData<(T, U)>,
 }
 
 impl SyncEditorBundle<(), ()> {
@@ -162,17 +163,12 @@ impl SyncEditorBundle<(), ()> {
     pub fn new() -> SyncEditorBundle<(), ()> {
         let (sender, receiver) = crossbeam_channel::unbounded();
         SyncEditorBundle {
-            component_names: Vec::new(),
-            resource_names: Vec::new(),
+            components: TypeSet::new(),
+            resources: TypeSet::new(),
             sender,
             receiver,
-            _phantom: PhantomData,
         }
     }
-}
-
-impl Default for SyncEditorBundle<(), ()> {
-    fn default() -> Self { SyncEditorBundle::new() }
 }
 
 impl<T, U> SyncEditorBundle<T, U> where
@@ -181,33 +177,57 @@ impl<T, U> SyncEditorBundle<T, U> where
 {
     /// Register a component for synchronizing with the editor. This will result in a
     /// [`SyncComponentSystem`] being added.
-    pub fn sync_component<C>(mut self, name: &'static str) -> SyncEditorBundle<(C, T), U>
+    pub fn sync_component<C>(self, name: &'static str) -> SyncEditorBundle<(T, (C,)), U>
     where
         C: Component + Serialize+Send,
     {
-        self.component_names.push(name);
         SyncEditorBundle {
-            component_names: self.component_names,
-            resource_names: self.resource_names,
+            components: self.components.with::<C>(name),
+            resources: self.resources,
             sender: self.sender,
             receiver: self.receiver,
-            _phantom: PhantomData,
+        }
+    }
+
+    /// Register a set of components for synchronizing with the editor. This will result
+    /// in a [`SyncComponentSystem`] being added for each component type in the set.
+    pub fn sync_components<C>(self, set: &TypeSet<C>) -> SyncEditorBundle<(T, C), U>
+    where
+        C: ComponentSet,
+    {
+        SyncEditorBundle {
+            components: self.components.with_set(set),
+            resources: self.resources,
+            sender: self.sender,
+            receiver: self.receiver,
         }
     }
 
     /// Register a resource for synchronizing with the editor. This will result in a
     /// [`SyncResourceSystem`] being added.
-    pub fn sync_resource<R>(mut self, name: &'static str) -> SyncEditorBundle<T, (R, U)>
+    pub fn sync_resource<R>(self, name: &'static str) -> SyncEditorBundle<T, (U, (R,))>
     where
         R: Resource + Serialize,
     {
-        self.resource_names.push(name);
         SyncEditorBundle {
-            component_names: self.component_names,
-            resource_names: self.resource_names,
+            components: self.components,
+            resources: self.resources.with::<R>(name),
             sender: self.sender,
             receiver: self.receiver,
-            _phantom: PhantomData,
+        }
+    }
+
+    /// Register a set of resources for synchronizing with the editor. This will result
+    /// in a [`SyncResourceSystem`] being added for each resource type in the set.
+    pub fn sync_resources<R>(self, set: &TypeSet<R>) -> SyncEditorBundle<T, (U, R)>
+    where
+        R: ResourceSet,
+    {
+        SyncEditorBundle {
+            components: self.components,
+            resources: self.resources.with_set(set),
+            sender: self.sender,
+            receiver: self.receiver,
         }
     }
 
@@ -221,18 +241,14 @@ impl<'a, 'b, T, U> SystemBundle<'a, 'b> for SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
 {
-    fn build(mut self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {
-        // In order to match the order of the type list.
-        self.component_names.reverse();
-        self.resource_names.reverse();
-
+    fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> BundleResult<()> {
         let sync_system = SyncEditorSystem::from_channel(self.sender, self.receiver);
         let connection = sync_system.get_connection();
 
         // All systems must have finished editing data before syncing can start.
         dispatcher.add_barrier();
-        T::create_sync_systems(dispatcher, &connection, &self.component_names);
-        U::create_sync_systems(dispatcher, &connection, &self.resource_names);
+        self.components.create_component_sync_systems(dispatcher, &connection);
+        self.resources.create_resource_sync_systems(dispatcher, &connection);
 
         // All systems must have finished serializing before it can be send to the editor.
         dispatcher.add_barrier();
@@ -407,44 +423,5 @@ impl<'a, T> System<'a> for SyncResourceSystem<T> where T: Resource+Serialize {
         } else {
             warn!("Resource named {:?} wasn't registered and will not show up in the editor", self.name);
         }
-    }
-}
-
-
-pub trait ComponentSet {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]);
-}
-
-impl ComponentSet for () {
-    fn create_sync_systems(_: &mut DispatcherBuilder, _: &EditorConnection, _: &[&'static str]) { }
-}
-
-impl<A, B> ComponentSet for (A, B)
-where
-    A: Component + Serialize + Send,
-    B: ComponentSet,
-{
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]) {
-        B::create_sync_systems(dispatcher, connection, &names[1..]);
-        dispatcher.add(SyncComponentSystem::<A>::new(names[0], connection.clone()), "", &[]);
-    }
-}
-
-pub trait ResourceSet {
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]);
-}
-
-impl ResourceSet for () {
-    fn create_sync_systems(_: &mut DispatcherBuilder, _: &EditorConnection, _: &[&'static str]) { }
-}
-
-impl<A, B> ResourceSet for (A, B)
-where
-    A: Resource + Serialize,
-    B: ResourceSet,
-{
-    fn create_sync_systems(dispatcher: &mut DispatcherBuilder, connection: &EditorConnection, names: &[&'static str]) {
-        B::create_sync_systems(dispatcher, connection, &names[1..]);
-        dispatcher.add(SyncResourceSystem::<A>::new(names[0], connection.clone()), "", &[]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,19 @@
 //! use amethyst_editor_sync::*;
 //!
 //! # fn main() -> Result<(), amethyst::Error> {
-//! // Create a `SyncEditorBundle` which will create all necessary systems to send the components
+//! // Specify every component that you want to view in the editor.
+//! let components = type_set![MyComponent];
+//! // Do the same for your resources.
+//! let resources = type_set![MyResource];
+//!
+//! // Create a SyncEditorBundle which will create all necessary systems to send the components
 //! // to the editor.
 //! let editor_sync_bundle = SyncEditorBundle::new()
-//!     // Register any engine-specific components you want to visualize.
-//!     .sync_component::<Transform>("Transform")
-//!     // Register any custom components that you use in your game.
-//!     .sync_component::<Foo>("Foo");
+//!     // Register the default types from the engine.
+//!     .sync_default_types()
+//!     // Register the components and resources specified above.
+//!     .sync_components(&components)
+//!     .sync_resources(&resources);
 //!
 //! let game_data = GameDataBuilder::default()
 //!     .with_bundle(editor_sync_bundle)?;
@@ -35,25 +41,29 @@
 //!
 //! // Make sure you enable serialization for your custom components and resources!
 //! #[derive(Serialize, Deserialize)]
-//! struct Foo {
-//!     bar: usize,
-//!     baz: String,
+//! struct MyComponent {
+//!     foo: usize,
+//!     bar: String,
 //! }
 //!
-//! impl Component for Foo {
+//! impl Component for MyComponent {
 //!     type Storage = DenseVecStorage<Self>;
+//! }
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct MyResource {
+//!     baz: usize,
 //! }
 //! ```
 //!
 //! # Usage
-//!
-//! First, create a [`SyncEditorBundle`] object. You must then register each of the component and
-//! resource types that you want to see in the editor:
-//!
-//! * For each component `T`, register the component with `sync_component::<T>(name)`, specifying
-//!   the name of the component and its concrete type.
-//! * For each resource, register the component with `sync_resource::<T>(name)`, specifying the
-//!   name of the resource and its concrete type.
+//! First, specify the components and resources that you want to see in the editor using the
+//! [`type_set!`] macro.
+//! Then create a [`SyncEditorBundle`] object and register the specified components and resources
+//! with `sync_components` and `sync_resources` respectively. Some of the engine-specific types can
+//! be registered automatically using the `sync_default_types` method. It is also possible to
+//! specify the types individually using `sync_component` and `sync_resource`, which allows changing
+//! the name of the type when viewed in the editor.
 //!
 //! Finally, add the [`SyncEditorBundle`] that you created to the game data.
 
@@ -80,6 +90,7 @@ pub use editor_log::EditorLogger;
 pub use ::serializable_entity::SerializableEntity;
 pub use type_set::{ComponentSet, ResourceSet, TypeSet};
 
+#[macro_use]
 mod type_set;
 mod editor_log;
 mod serializable_entity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,25 @@ impl<T, U> SyncEditorBundle<T, U> where
     T: ComponentSet,
     U: ResourceSet,
 {
+    /// Synchronize amethyst types.
+    ///
+    /// Currently only a small set is supported. This will be expanded in the future.
+    pub fn sync_default_types(
+        self
+    ) -> SyncEditorBundle<(T, impl ComponentSet), (U, impl ResourceSet)> {
+        use amethyst::renderer::{AmbientColor, Camera, Light};
+        use amethyst::core::{GlobalTransform, Transform};
+
+        let components = type_set![Light, Camera, Transform, GlobalTransform];
+        let resources = type_set![AmbientColor];
+        SyncEditorBundle {
+            components: self.components.with_set(&components),
+            resources: self.resources.with_set(&resources),
+            sender: self.sender,
+            receiver: self.receiver,
+        }
+    }
+
     /// Register a component for synchronizing with the editor. This will result in a
     /// [`SyncComponentSystem`] being added.
     pub fn sync_component<C>(self, name: &'static str) -> SyncEditorBundle<(T, (C,)), U>

--- a/src/type_set.rs
+++ b/src/type_set.rs
@@ -1,0 +1,203 @@
+use amethyst::ecs::prelude::*;
+use amethyst::ecs::shred::Resource;
+use serde::Serialize;
+use std::marker::PhantomData;
+
+use {EditorConnection, SyncComponentSystem, SyncResourceSystem};
+
+/// Create a set of types, where the value is the stringified typename.
+#[macro_export]
+macro_rules! type_set {
+    ( $($t:ty),* ) => {
+        {
+            let type_set = TypeSet::new();
+            $(
+                let type_set = type_set.with::<$t>(stringify!($t));
+            )*
+            type_set
+        }
+    };
+}
+
+/// A set of types with associated data.
+///
+/// `T` is essentially a tree built of 0-2 tuples.
+pub struct TypeSet<T> {
+    // Stored in left to right traversal order of the type tree.
+    names: Vec<&'static str>,
+    _phantom: PhantomData<T>,
+}
+
+impl TypeSet<()> {
+    /// Construct an empty set.
+    pub fn new() -> Self {
+        TypeSet {
+            names: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> TypeSet<T> {
+    /// Insert a type.
+    pub fn with<U>(mut self, value: &'static str) -> TypeSet<(T, (U,))> {
+        self.names.push(value);
+        TypeSet {
+            names: self.names,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Insert each type in the given set.
+    pub fn with_set<U>(mut self, set: &TypeSet<U>) -> TypeSet<(T, U)> {
+        self.names.extend(&set.names);
+        TypeSet {
+            names: self.names,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> TypeSet<T>
+where
+    T: ComponentSet,
+{
+    /// Create a component-synchronization system for each type in the set.
+    pub(crate) fn create_component_sync_systems(
+        &self,
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+    ) {
+        T::create_sync_systems(dispatcher, connection, &self.names);
+    }
+}
+
+impl<T> TypeSet<T>
+where
+    T: ResourceSet,
+{
+    /// Create a resource-synchronization system for each type in the set.
+    pub(crate) fn create_resource_sync_systems(
+        &self,
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+    ) {
+        T::create_sync_systems(dispatcher, connection, &self.names);
+    }
+}
+
+/// A type that groups component types.
+///
+/// This is an implementation detail used to construct synchronization systems.
+pub trait ComponentSet {
+    /// Create the synchronization systems.
+    ///
+    /// Their names are passed in the order they are inserted into the type set.
+    /// Returns the number of systems created.
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize;
+}
+
+impl ComponentSet for () {
+    fn create_sync_systems(
+        _: &mut DispatcherBuilder,
+        _: &EditorConnection,
+        _: &[&'static str],
+    ) -> usize {
+        0
+    }
+}
+
+impl<T> ComponentSet for (T,)
+where
+    T: Component + Serialize + Send,
+{
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize {
+        dispatcher.add(
+            SyncComponentSystem::<T>::new(names[0], connection.clone()),
+            "",
+            &[],
+        );
+        1
+    }
+}
+
+impl<T, U> ComponentSet for (T, U)
+where
+    T: ComponentSet,
+    U: ComponentSet,
+{
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize {
+        let idx = T::create_sync_systems(dispatcher, connection, names);
+        idx + U::create_sync_systems(dispatcher, connection, &names[idx..])
+    }
+}
+
+/// A type that groups resource types.
+///
+/// This is an implementation detail used to construct synchronization systems.
+pub trait ResourceSet {
+    /// Create the synchronization systems.
+    ///
+    /// Their names are passed in the order they are inserted into the type set.
+    /// Returns the number of systems created.
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize;
+}
+
+impl ResourceSet for () {
+    fn create_sync_systems(
+        _: &mut DispatcherBuilder,
+        _: &EditorConnection,
+        _: &[&'static str],
+    ) -> usize {
+        0
+    }
+}
+
+impl<T> ResourceSet for (T,)
+where
+    T: Resource + Serialize,
+{
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize {
+        dispatcher.add(
+            SyncResourceSystem::<T>::new(names[0], connection.clone()),
+            "",
+            &[],
+        );
+        1
+    }
+}
+
+impl<T, U> ResourceSet for (T, U)
+where
+    T: ResourceSet,
+    U: ResourceSet,
+{
+    fn create_sync_systems(
+        dispatcher: &mut DispatcherBuilder,
+        connection: &EditorConnection,
+        names: &[&'static str],
+    ) -> usize {
+        let idx = T::create_sync_systems(dispatcher, connection, names);
+        idx + U::create_sync_systems(dispatcher, connection, &names[idx..])
+    }
+}


### PR DESCRIPTION
A solution to #19 and #20.

The syntax would be
```rust
let components = type_set![Foo, Bar];
let bundle = SyncEditorBundle::new()
    .sync_default_types()
    .sync_components(&components);
```
This is more flexible than using a macro to construct the bundle itself. For example it makes it easy to switch between different sets of synced types.