### PR TITLE
Add support for editing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `sync_components` and `sync_resources` methods in `SyncEditorBundle` to synchronize all types in a `TypeSet`. `TypeSets` can be created through the `type_set!` macro to reduce the verbosity of synchronizing many types. ([#19])
-* `sync_default_types` method in `SyncEditorBundle` to easily synchronize some commonly used engine types. ([#20])
-
+* `sync_components` and `sync_resources` methods in `SyncEditorBundle` to synchronize all types
+  in a `TypeSet`. `TypeSets` can be created through the `type_set!` macro to reduce the verbosity
+  of synchronizing many types. ([#19])
+* `sync_default_types` method in `SyncEditorBundle` to easily synchronize some commonly used
+  engine types. ([#20])
+* :tada: Support for editing `Resource` values! :tada: ([#25])
 
 ### Breaking Changes
 
 * `SyncEditorBundle` type format. If the type is explicitly given, it will need to be updated. ([#21])
+* Resources registered via `SyncEditorBundle::sync_resource` must now be `DeserializeOwned` (as
+  well as `Serialize`). This enables support for applying changes made in the editor. If you have
+  a `Resource` that only implements `Serialize`, register it with `SyncEditorBundle::read_resource`
+  instead. ([#25])
+* `SyncResourceSystem` has been removed. If your code was directly registering the sync systems
+  with your dispatcher, please update to using `SyncEditorBundle` instead. ([#25])
 
 [#19]: https://github.com/randomPoison/amethyst-editor-sync/issues/19
 [#20]: https://github.com/randomPoison/amethyst-editor-sync/issues/20
 [#21]: https://github.com/randomPoison/amethyst-editor-sync/pull/21
+[#25]: https://github.com/randomPoison/amethyst-editor-sync/pull/25
 
 ## [0.2.0] - 2018-10-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-once 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "shred-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1050,6 +1051,14 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log-once"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2256,6 +2265,7 @@ dependencies = [
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum log-once 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9720993e443658f80c82a386d503b8a4dfbaac77742b8b8977ac94df1346e245"
 "checksum mach 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "977262a11cfd76b94da10b8898cea6e9ac391301ab74741e6da6bee13d7df46d"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shred-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crossbeam-channel = "0.2.4"
 log = "0.4.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shred-derive = "0.5"
 
 [dev-dependencies]
 env_logger = "0.5.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 amethyst = "0.8"
 crossbeam-channel = "0.2.4"
 log = "0.4.4"
+log-once = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shred-derive = "0.5"

--- a/examples/pong/bundle.rs
+++ b/examples/pong/bundle.rs
@@ -1,6 +1,6 @@
 use amethyst::core::bundle::{Result, SystemBundle};
 use amethyst::ecs::prelude::DispatcherBuilder;
-use systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
+use systems::{BounceSystem, MoveBallsSystem, PaddleSystem, ScoreTextSystem, WinnerSystem};
 
 /// A bundle is a convenient way to initialise related resources, components and systems in a
 /// world. This bundle prepares the world for a game of pong.
@@ -19,6 +19,11 @@ impl<'a, 'b> SystemBundle<'a, 'b> for PongBundle {
             WinnerSystem,
             "winner_system",
             &["paddle_system", "ball_system"],
+        );
+        builder.add(
+            ScoreTextSystem,
+            "score_text_system",
+            &["winner_system"],
         );
         Ok(())
     }

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -73,7 +73,7 @@ fn main() -> amethyst::Result<()> {
     let editor_sync_bundle = SyncEditorBundle::new()
         .sync_default_types()
         .sync_components(&components)
-        .sync_resource::<ScoreBoard>("ScoreBoard");
+        .sync_resource::<ScoreBoard>("Score Board");
     EditorLogger::new(editor_sync_bundle.get_connection()).start();
     let game_data = GameDataBuilder::default()
         .with_bundle(

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -47,6 +47,8 @@ const AUDIO_SCORE: &'static str = "audio/score.ogg";
 fn main() -> amethyst::Result<()> {
     use pong::Pong;
 
+    amethyst::start_logger(Default::default());
+
     let display_config_path = format!(
         "{}/examples/pong/resources/display.ron",
         env!("CARGO_MANIFEST_DIR")

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -133,7 +133,7 @@ impl Component for Paddle {
     type Storage = DenseVecStorage<Self>;
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[derive(Default)]
 pub struct ScoreBoard {
     score_left: i32,

--- a/examples/pong/systems/mod.rs
+++ b/examples/pong/systems/mod.rs
@@ -1,9 +1,19 @@
+use amethyst::ecs::Entity;
+
 mod bounce;
 mod move_balls;
 mod paddle;
+mod score_text;
 mod winner;
 
 pub use self::bounce::BounceSystem;
 pub use self::move_balls::MoveBallsSystem;
 pub use self::paddle::PaddleSystem;
-pub use self::winner::{ScoreText, WinnerSystem};
+pub use self::score_text::ScoreTextSystem;
+pub use self::winner::WinnerSystem;
+
+/// Stores the entities that are displaying the player score with UiText.
+pub struct ScoreText {
+    pub p1_score: Entity,
+    pub p2_score: Entity,
+}

--- a/examples/pong/systems/score_text.rs
+++ b/examples/pong/systems/score_text.rs
@@ -1,0 +1,31 @@
+use ::{ScoreBoard};
+use ::systems::ScoreText;
+use amethyst::ecs::prelude::{Read, ReadExpect, System, WriteStorage};
+use amethyst::ui::UiText;
+
+pub struct ScoreTextSystem;
+
+impl<'s> System<'s> for ScoreTextSystem {
+    type SystemData = (
+        WriteStorage<'s, UiText>,
+        Read<'s, ScoreBoard>,
+        ReadExpect<'s, ScoreText>,
+    );
+
+    fn run(
+        &mut self,
+        (
+            mut text,
+            score_board,
+            score_text,
+        ): Self::SystemData,
+    ) {
+        if let Some(text) = text.get_mut(score_text.p2_score) {
+            text.text = score_board.score_right.to_string();
+        }
+
+        if let Some(text) = text.get_mut(score_text.p1_score) {
+            text.text = score_board.score_left.to_string();
+        }
+    }
+}

--- a/examples/pong/systems/winner.rs
+++ b/examples/pong/systems/winner.rs
@@ -2,8 +2,7 @@ use amethyst::assets::AssetStorage;
 use amethyst::audio::output::Output;
 use amethyst::audio::Source;
 use amethyst::core::transform::Transform;
-use amethyst::ecs::prelude::{Entity, Join, Read, ReadExpect, System, Write, WriteStorage};
-use amethyst::ui::UiText;
+use amethyst::ecs::prelude::{Join, Read, ReadExpect, System, Write, WriteStorage};
 use audio::Sounds;
 use {Ball, ScoreBoard};
 
@@ -16,11 +15,9 @@ impl<'s> System<'s> for WinnerSystem {
     type SystemData = (
         WriteStorage<'s, Ball>,
         WriteStorage<'s, Transform>,
-        WriteStorage<'s, UiText>,
         Write<'s, ScoreBoard>,
         Read<'s, AssetStorage<Source>>,
         ReadExpect<'s, Sounds>,
-        ReadExpect<'s, ScoreText>,
         Option<Read<'s, Output>>,
     );
 
@@ -29,11 +26,9 @@ impl<'s> System<'s> for WinnerSystem {
         (
             mut balls,
             mut transforms,
-            mut text,
             mut score_board,
             storage,
             sounds,
-            score_text,
             audio_output,
         ): Self::SystemData,
     ) {
@@ -45,16 +40,10 @@ impl<'s> System<'s> for WinnerSystem {
             let did_hit = if ball_x <= ball.radius {
                 // Right player scored on the left side.
                 score_board.score_right += 1;
-                if let Some(text) = text.get_mut(score_text.p2_score) {
-                    text.text = score_board.score_right.to_string();
-                }
                 true
             } else if ball_x >= ARENA_WIDTH - ball.radius {
                 // Left player scored on the right side.
                 score_board.score_left += 1;
-                if let Some(text) = text.get_mut(score_text.p1_score) {
-                    text.text = score_board.score_left.to_string();
-                }
                 true
             } else {
                 false
@@ -80,10 +69,4 @@ impl<'s> System<'s> for WinnerSystem {
             }
         }
     }
-}
-
-/// Stores the entities that are displaying the player score with UiText.
-pub struct ScoreText {
-    pub p1_score: Entity,
-    pub p2_score: Entity,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,10 @@ enum SerializedData {
     Message(String),
 }
 
+/// Messages sent from the editor to the game.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
-enum IncomingMessageEnum {
+enum IncomingMessage {
     ResourceUpdate {
         id: String,
         data: serde_json::Value,
@@ -456,12 +457,12 @@ impl<'a> System<'a> for SyncEditorSystem {
             // once NLL is stable.
             {
                 let message_bytes = &self.incoming_buffer[..index];
-                let result: Option<IncomingMessageEnum> = str::from_utf8(message_bytes)
+                let result = str::from_utf8(message_bytes)
                     .ok()
-                    .and_then(|message| serde_json::from_str::<IncomingMessageEnum>(message).ok());
+                    .and_then(|message| serde_json::from_str(message).ok());
                 match result {
                     Some(message) => match message {
-                        IncomingMessageEnum::ResourceUpdate { id, data } => {
+                        IncomingMessage::ResourceUpdate { id, data } => {
                             // TODO: Should we do something if there was no deserialer system for the
                             // specified ID?
                             if let Some(sender) = self.deserializer_map.get(&*id) {

--- a/src/read_resource.rs
+++ b/src/read_resource.rs
@@ -6,7 +6,13 @@ use serde_json;
 use std::marker::PhantomData;
 
 /// A system that serializes a resource of a specific type and sends it to the
-/// [`SyncEditorSystem`], which will sync it with the editor.
+/// [`SyncEditorSystem`].
+///
+/// An instance of this system will be created for each resource type the user
+/// registers with the [`SyncEditorBundle`] when initializing their game.
+///
+/// [`SyncEditorSystem`]: ./struct.SyncEditorSystem.html
+/// [`SyncEditorBundle`]: ./struct.SyncEditorBundle.html
 pub(crate) struct ReadResourceSystem<T> {
     name: &'static str,
     connection: EditorConnection,
@@ -39,6 +45,7 @@ impl<'a, T> System<'a> for ReadResourceSystem<T> where T: Resource + Serialize {
             name: self.name,
             data: &*resource,
         };
+
         if let Ok(serialized) = serde_json::to_string(&serialize_data) {
             self.connection.send_data(SerializedData::Resource(serialized));
         } else {

--- a/src/read_resource.rs
+++ b/src/read_resource.rs
@@ -1,0 +1,44 @@
+use ::{EditorConnection, SerializedData, SerializedResource};
+use amethyst::shred::Resource;
+use amethyst::ecs::*;
+use serde::Serialize;
+use serde_json;
+use std::marker::PhantomData;
+
+/// A system that serializes a resource of a specific type and sends it to the
+/// [`SyncEditorSystem`], which will sync it with the editor.
+pub(crate) struct ReadResourceSystem<T> {
+    name: &'static str,
+    connection: EditorConnection,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> ReadResourceSystem<T> {
+    pub(crate) fn new(name: &'static str, connection: EditorConnection) -> Self {
+        Self {
+            name,
+            connection,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> System<'a> for ReadResourceSystem<T> where T: Resource + Serialize {
+    type SystemData = Option<Read<'a, T>>;
+
+    fn run(&mut self, resource: Self::SystemData) {
+        if let Some(resource) = resource {
+            let serialize_data = SerializedResource {
+                name: self.name,
+                data: &*resource,
+            };
+            if let Ok(serialized) = serde_json::to_string(&serialize_data) {
+                self.connection.send_data(SerializedData::Resource(serialized));
+            } else {
+                warn!("Failed to serialize resource of type {}", self.name);
+            }
+        } else {
+            warn!("Resource named {:?} wasn't registered and will not show up in the editor", self.name);
+        }
+    }
+}

--- a/src/type_set.rs
+++ b/src/type_set.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
-use {EditorConnection, DeserializerMap, SyncComponentSystem, ReadResourceSystem};
+use {EditorConnection, DeserializerMap, SyncComponentSystem};
+use read_resource::ReadResourceSystem;
 use write_resource::WriteResourceSystem;
 
 /// Create a set of types, where the value is the stringified typename.

--- a/src/type_set.rs
+++ b/src/type_set.rs
@@ -206,7 +206,7 @@ where
         dispatcher.add(
             ReadResourceSystem::<T>::new(names[0], connection.clone()),
             "",
-            &["editor_sync_system"],
+            &[],
         );
         1
     }
@@ -220,7 +220,7 @@ where
         dispatcher.add(
             WriteResourceSystem::<T>::new(names[0], receiver),
             "",
-            &["editor_sync_system"],
+            &[],
         );
         deserializer_map.insert(names[0], sender);
         1

--- a/src/type_set.rs
+++ b/src/type_set.rs
@@ -205,8 +205,8 @@ where
     ) -> usize {
         dispatcher.add(
             ReadResourceSystem::<T>::new(names[0], connection.clone()),
-            "editor_sync_system",
-            &[],
+            "",
+            &["editor_sync_system"],
         );
         1
     }
@@ -219,8 +219,8 @@ where
         let (sender, receiver) = crossbeam_channel::unbounded();
         dispatcher.add(
             WriteResourceSystem::<T>::new(names[0], receiver),
-            "editor_sync_system",
-            &[],
+            "",
+            &["editor_sync_system"],
         );
         deserializer_map.insert(names[0], sender);
         1

--- a/src/write_resource.rs
+++ b/src/write_resource.rs
@@ -8,12 +8,12 @@ use std::marker::PhantomData;
 /// A system that deserializes incoming updates for a resource and applies them to the local
 /// instance of that resource.
 pub(crate) struct WriteResourceSystem<T> {
-    incoming: Receiver<String>,
+    incoming: Receiver<serde_json::Value>,
     _phantom: PhantomData<T>,
 }
 
 impl<T> WriteResourceSystem<T> {
-    pub(crate) fn new(incoming: Receiver<String>) -> Self {
+    pub(crate) fn new(incoming: Receiver<serde_json::Value>) -> Self {
         WriteResourceSystem {
             incoming,
             _phantom: PhantomData,
@@ -25,13 +25,13 @@ impl<'a, T> System<'a> for WriteResourceSystem<T> where T: Resource + Deserializ
     type SystemData = Option<Write<'a, T>>;
 
     fn run(&mut self, mut data: Self::SystemData) {
-        let mut resource = match {
+        let mut resource = match data {
             Some(res) => res,
             None => return,
         };
 
         while let Some(incoming) = self.incoming.try_recv() {
-            let updated = match serde_json::from_str(&incoming) {
+            let updated = match serde_json::from_value(incoming) {
                 Ok(updated) => updated,
                 Err(_) => continue,
             };

--- a/src/write_resource.rs
+++ b/src/write_resource.rs
@@ -5,8 +5,13 @@ use serde::de::DeserializeOwned;
 use serde_json;
 use std::marker::PhantomData;
 
-/// A system that deserializes incoming updates for a resource and applies them to the local
-/// instance of that resource.
+/// A system that deserializes incoming updates for a resource and applies
+/// them to the world state.
+///
+/// An instance of this system is created for each writable resource registered
+/// with [`SyncEditorBundle`] by the player during setup for their game.
+///
+/// [`SyncEditorBundle`]: ./struct.SyncEditorBundle.html
 pub(crate) struct WriteResourceSystem<T> {
     id: &'static str,
     incoming: Receiver<serde_json::Value>,

--- a/src/write_resource.rs
+++ b/src/write_resource.rs
@@ -1,0 +1,42 @@
+use amethyst::shred::Resource;
+use amethyst::ecs::*;
+use crossbeam_channel::Receiver;
+use serde::de::DeserializeOwned;
+use serde_json;
+use std::marker::PhantomData;
+
+/// A system that deserializes incoming updates for a resource and applies them to the local
+/// instance of that resource.
+pub(crate) struct WriteResourceSystem<T> {
+    incoming: Receiver<String>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> WriteResourceSystem<T> {
+    pub(crate) fn new(incoming: Receiver<String>) -> Self {
+        WriteResourceSystem {
+            incoming,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> System<'a> for WriteResourceSystem<T> where T: Resource + DeserializeOwned {
+    type SystemData = Option<Write<'a, T>>;
+
+    fn run(&mut self, mut data: Self::SystemData) {
+        let mut resource = match {
+            Some(res) => res,
+            None => return,
+        };
+
+        while let Some(incoming) = self.incoming.try_recv() {
+            let updated = match serde_json::from_str(&incoming) {
+                Ok(updated) => updated,
+                Err(_) => continue,
+            };
+
+            *resource = updated;
+        }
+    }
+}

--- a/src/write_resource.rs
+++ b/src/write_resource.rs
@@ -27,6 +27,8 @@ impl<'a, T> System<'a> for WriteResourceSystem<T> where T: Resource + Deserializ
     type SystemData = Option<Write<'a, T>>;
 
     fn run(&mut self, data: Self::SystemData) {
+        trace!("`WriteResourceSystem::run` for {}", self.id);
+
         let mut resource = match data {
             Some(res) => res,
             None => return,

--- a/src/write_resource.rs
+++ b/src/write_resource.rs
@@ -35,9 +35,14 @@ impl<'a, T> System<'a> for WriteResourceSystem<T> where T: Resource + Deserializ
         };
 
         while let Some(incoming) = self.incoming.try_recv() {
+            debug!("Got incoming message for {}: {:?}", self.id, incoming);
+
             let updated = match serde_json::from_value(incoming) {
                 Ok(updated) => updated,
-                Err(_) => continue,
+                Err(error) => {
+                    debug!("Failed to deserialize update for {}: {:?}", self.id, error);
+                    continue;
+                }
             };
 
             *resource = updated;

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -6,7 +6,7 @@ extern crate serde;
 use amethyst::prelude::*;
 use amethyst_editor_sync::*;
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct SimpleResource {
     value: usize,
 }


### PR DESCRIPTION
This implements basic support for receiving updated data for resources from the editor and applying those updates to the local state. Currently this is only implemented for resources, however the same pattern can be easily implemented for components.

* Split `SyncResourceSystem` into `ReadResourceSystem` and `WriteResourceSystem`.
* Add functionality to `SyncEditorSystem` to read incoming update data and dispatch it to the corresponding `WriteResourceSystem`.
* Add the requirement that registered resources be `DeserializeOwned`. We should add an API for registering read-only resources for when a resource only implements `Serialize`.
* Make some tweaks to the pong example so that changes to the `ScoreBoard` resource show up more immediately (useful for demo purposes).

Lots of easy ways to improve this, but I'd rather get this merged in with the functionality as-is. I'll write up some tickets to track the remainder of the cleanup work, that way others can have a chance to contribute.